### PR TITLE
nodejs-current-npm removed from alpine:edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:edge
 RUN \
 echo http://dl-4.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
 apk add --no-cache mongodb && \
-apk add --no-cache nodejs-current-npm && \
+apk add --no-cache nodejs && \
 rm /usr/bin/mongoperf
 
 VOLUME /database


### PR DESCRIPTION
renamed to nodejs